### PR TITLE
add python-black-statement: reformat the current statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,20 @@ Usage
 Use one of these commands via `M-x` or bind them to a key:
 
 - `python-black-buffer`
-- `python-black-region` (requires `black-macchiato`)
+
+  Reformat the current buffer.
+
+- `python-black-region`
+
+  Reformat the current region. (Requires `black-macchiato`.)
+
+- `python-black-statement`
+
+  Reformat the current statement. (Requires `black-macchiato`.)
+
 - `python-black-on-save-mode`
+
+  Automatically reformat the buffer on save.
 
 Configuration
 -------------

--- a/python-black.el
+++ b/python-black.el
@@ -15,6 +15,7 @@
 ;;; Code:
 
 (require 'dash)
+(require 'python)
 (require 'reformatter)
 
 (defgroup python-black nil
@@ -48,6 +49,21 @@
   :args (python-black--make-args beg end)
   :lighter " BlackFMT"
   :group 'python-black)
+
+;;;###autoload
+(defun python-black-statement (&optional display-errors)
+  "Reformats the current statement.
+
+When called interactively with a prefix argument, or when
+DISPLAY-ERRORS is non-nil, shows a buffer if the formatting fails."
+  (interactive "p")
+  (let ((beg (save-excursion
+               (python-nav-beginning-of-statement)
+               (line-beginning-position)))
+        (end (save-excursion
+               (python-nav-end-of-statement)
+               (1+ (line-end-position)))))
+    (python-black-region beg end display-errors)))
 
 (defun python-black--command (beg end)
   "Helper to decide which command to run for span BEG to END."


### PR DESCRIPTION
This adds a `python-black-statement` interactive command to reformat the Python statement at point. Python statement boundary detection uses the built-in `python.el` navigation functions (`python-nav-*`).