### PR TITLE
pass buffer file name to ‘black --stdin-filename …’

### DIFF
--- a/python-black.el
+++ b/python-black.el
@@ -117,6 +117,8 @@ DISPLAY-ERRORS is non-nil, shows a buffer if the formatting fails."
   "Helper to build the argument list for black for span BEG to END."
   (append
    python-black--base-args
+   (-when-let* ((file-name (buffer-file-name)))
+     `("--stdin-filename" ,file-name))
    (-when-let* ((file-name (buffer-file-name))
                 (extension (file-name-extension file-name))
                 (is-pyi-file (string-equal "pyi" extension)))


### PR DESCRIPTION
pass the file name (if any) to black via the ‘--stdin-filename’ command line flag. it will be used to discover the project root directory and hence the configuration file (see find_project_root() callers in the black sources), instead of the default behaviour:

> If you’re formatting standard input, Black will look for
> configuration starting from the current working directory.
> – https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#where-black-looks-for-the-file

closes #13.