### PR TITLE
Fix byte compiler warnings

### DIFF
--- a/python-black.el
+++ b/python-black.el
@@ -93,9 +93,15 @@ DISPLAY-ERRORS is non-nil, shows a buffer if the formatting fails."
       (python-black-region (region-beginning) (region-end) display-errors)
     (python-black-statement display-errors)))
 
+(declare-function org-in-block-p "org" (names))
+(declare-function org-src--contents-area "org-src" (datum))
+(declare-function org-element-at-point "org-element" (&optional pom cached-only))
+
 ;;;###autoload
 (defun python-black-org-mode-block (&optional display-errors)
-  "Reformats the current org-mode source block."
+  "Reformats the current `org-mode' source block.
+When called interactively, or with prefix argument
+DISPLAY-ERRORS, shows a buffer if the formatting fails."
   (interactive)
   (unless (org-in-block-p '("src" "example"))
     (user-error "Not in a source block"))


### PR DESCRIPTION
Should eliminate all byte compiler warnings during native compilation on Emacs 29.